### PR TITLE
fixed errors not displaying issue

### DIFF
--- a/example/json_logger/main.go
+++ b/example/json_logger/main.go
@@ -22,6 +22,32 @@ func main() {
 	lg.Error("message")
 	lg.Error("message", "param1", "param2")
 
+	// log complex structures
+	type ABC struct {
+		CDE string
+		def string
+	}
+	cpx := ABC{CDE: "some string", def: "some unexported string"}
+
+	lg.Trace("log complex", "param1", cpx)
+	lg.TraceContext(context.Background(), "log complex", "param1", cpx)
+
+	// log error values
+	err := fmt.Errorf("error: %s", "plain error")
+	lg.Error("error", err)
+
+	// log embedded errors
+	type WrappedError struct {
+		error
+	}
+
+	errWrapped := WrappedError{
+		fmt.Errorf("inner error"),
+	}
+
+	lg.Error("wrapped error", errWrapped)
+	lg.ErrorContext(context.Background(), "contexed-error", errWrapped)
+
 	// log with a traceable context
 	tCtx := traceable_context.WithUUID(uuid.New())
 	ctx, fn := context.WithCancel(tCtx)

--- a/example/text_logger/main.go
+++ b/example/text_logger/main.go
@@ -39,6 +39,17 @@ func main() {
 	logger.ErrorContext(ctx, log.WithPrefix(`prefix`, `message`))
 	logger.WarnContext(ctx, log.WithPrefix(`prefix`, `message`), `param1`, `param2`)
 
+	type WrappedError struct {
+		error
+	}
+
+	errWrapped := WrappedError{
+		fmt.Errorf(`wrapped error: %s`, `inner error`),
+	}
+
+	logger.Error("error", errWrapped)
+	logger.ErrorContext(context.Background(), "contexed-error", errWrapped)
+
 	// sub logger with traceable context
 	subLogger := logger.NewLog(log.Prefixed("sub-logger"))
 	subLogger.ErrorContext(ctx, "message", "with trace")

--- a/json_parser.go
+++ b/json_parser.go
@@ -90,7 +90,12 @@ func (l *jsonLogParser) withParams(event *zerolog.Event, params ...interface{}) 
 		return event
 	}
 
-	return event.Interface("params", params)
+	arr := zerolog.Arr()
+	for _, param := range params {
+		arr.Str(fmt.Sprintf("%+v", param))
+	}
+
+	return event.Array("params", arr)
 }
 
 // withCallerInfo adds caller info to the event.


### PR DESCRIPTION
Added a fix to render params array as an array of strings using `fmt.Sprintf`.
Closes #3 