### PR TITLE
Fix: Remove redundant parameter values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tryfix/log
+module github.com/YasiruR/log
 
 go 1.14
 

--- a/text_parser.go
+++ b/text_parser.go
@@ -19,8 +19,11 @@ func (l *logParser) WithPrefix(p string, message interface{}) string {
 		if p == "" {
 			return fmt.Sprintf("%s] [%+v", l.prefix, message)
 		}
-
 		return fmt.Sprintf("%s.%s] [%+v", l.prefix, p, message)
+	}
+
+	if p == "" {
+		return fmt.Sprintf("%+v", message)
 	}
 
 	return fmt.Sprintf("%s] [%+v", p, message)
@@ -49,16 +52,18 @@ func (l *logParser) logEntry(ctx context.Context, level Level, message interface
 	}
 
 	var params []interface{}
-	format := "%s [%s] [%+v]"
 	logLevel := l.colored(level)
 
 	// add extracted trace id
-	var traceID string
+	var format, traceID string
 	if l.ctxTraceExt != nil {
+		format = "%s [%s] [%+v]"
 		traceID = l.ctxTraceExt(ctx)
+		params = append(params, logLevel, traceID, fmt.Sprintf("%v", message))
+	} else {
+		format = "%s [%s]"
+		params = append(params, logLevel, fmt.Sprintf("%v", message))
 	}
-
-	params = append(params, logLevel, traceID, fmt.Sprintf("%v", message))
 
 	if l.filePath || l.funcPath {
 		format = l.applyCallerInfo(format)

--- a/text_parser.go
+++ b/text_parser.go
@@ -65,7 +65,7 @@ func (l *logParser) logEntry(ctx context.Context, level Level, message interface
 	}
 
 	if l.filePath || l.funcPath {
-		format += l.appendCallerInfo(format)
+		format += l.callerInfoSuffix()
 	} else {
 		format += "]"
 	}
@@ -97,7 +97,7 @@ func (l *logParser) logEntry(ctx context.Context, level Level, message interface
 	l.log.Printf(format, params...)
 }
 
-func (l *logParser) appendCallerInfo(format string) string {
+func (l *logParser) callerInfoSuffix() string {
 	funcName := "<Unknown>"
 	file := "<Unknown>"
 	line := 0


### PR DESCRIPTION
This PR fixes #7 

Changes (text_logger):
- removed logging empty params
- append-based log entry construction

Benchmark result comparison:
![comparison](https://github.com/user-attachments/assets/216afef3-8d58-4109-af54-71bf157a3a99)

Refer to the following csv files for complete results:
[previous_results.csv](https://github.com/user-attachments/files/18386435/previous_results.csv)
[new_results.csv](https://github.com/user-attachments/files/18386436/new_results.csv)
